### PR TITLE
Fix the reference submission image so it runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,3 +175,52 @@ jobs:
           PYEOF
       - name: Validate all public units
         run: python .github/validate_units.py forecasting
+
+  image:
+    name: Build the reference image and run the verb inside it
+    runs-on: ubuntu-latest
+    # A CodaBench submission IS the Docker image, so the image -- not the package -- is the
+    # deliverable. Until this job existed nothing ever built it: `Dockerfile` shipped without
+    # `qfbench2-common` for as long as it took someone to run it by hand, because a green CI
+    # over the package says nothing about whether the image can start.
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Build
+        # linux/amd64 only. The Dockerfile also claims linux/arm64; emulating it here costs
+        # more than it catches, so arm64 stays a manual check before a release.
+        run: docker build -t t2-reference:ci .
+      - name: The verb starts
+        # The whole point. `docker build` succeeding proves nothing -- the failure this job
+        # exists to catch was an image that built clean and then died on its first import.
+        run: docker run --rm t2-reference:ci forecast --help
+      - name: The shared toolkit is importable inside the image
+        run: |
+          docker run --rm -i t2-reference:ci python3 - <<'PYEOF'
+          import sys
+          try:
+              from qfbench2_common.contracts import CONTRACT_SET
+          except Exception as exc:
+              sys.exit(f"toolkit not importable inside the image ({exc})")
+          print("contract set", CONTRACT_SET)
+          PYEOF
+      - name: Every dependency is at the version the Dockerfile pins
+        # An image that floats its deps fails the same way a pinned type checker meeting an
+        # unpinned numpy did. `scipy` is here because the toolkit depends on it: nothing in
+        # this repo imports it directly, so only an explicit check keeps it pinned.
+        run: |
+          docker run --rm -i t2-reference:ci python3 - <<'PYEOF'
+          import importlib.metadata as m
+          want = {"numpy": "2.1.3", "pandas": "2.2.3", "pyarrow": "18.1.0",
+                  "jsonschema": "4.23.0", "scipy": "1.18.1", "qfbench2-common": "2.3.1"}
+          bad = [f"{p}: {m.version(p)} != {v}" for p, v in want.items() if m.version(p) != v]
+          if bad:
+              raise SystemExit("unpinned drift inside the image: " + "; ".join(bad))
+          print("all pins match")
+          PYEOF
+      - name: It runs with no network, the way the harness runs it
+        run: docker run --rm --network=none t2-reference:ci forecast --help
+      - name: It runs as a non-root user
+        run: |
+          uid=$(docker run --rm t2-reference:ci id -u)
+          [ "$uid" != "0" ] || { echo "image runs as root; the harness expects a non-root user" >&2; exit 1; }
+          echo "uid $uid"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # The toolkit installs from a source tarball, not `git+https://`: pip shells out to a
 # `git` binary for a VCS URL and this slim base ships none, so the VCS form fails the
 # build. Same repository, same pinned `v2.3.1` tag.
+#
+# `scipy` is pinned here although nothing in this repo imports it directly: it arrives as
+# a dependency of the toolkit, whose floor is `scipy>=1.11`. Left implicit it would be the
+# one floating dependency in an image that pins everything else.
 RUN pip install --no-cache-dir \
         "numpy==2.1.3" \
         "pandas==2.2.3" \
         "pyarrow==18.1.0" \
         "jsonschema==4.23.0" \
+        "scipy==1.18.1" \
         "qfbench2-common @ https://github.com/Agenthon-2026/Agenthon2026-public/archive/refs/tags/v2.3.1.tar.gz#subdirectory=common"
 
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # Pinned. The scorer's own CI was red for a week because a pinned type checker met an unpinned
 # numpy; a submission image that floats its deps has the same failure mode with worse timing.
+#
+# The toolkit installs from a source tarball, not `git+https://`: pip shells out to a
+# `git` binary for a VCS URL and this slim base ships none, so the VCS form fails the
+# build. Same repository, same pinned `v2.3.1` tag.
 RUN pip install --no-cache-dir \
         "numpy==2.1.3" \
         "pandas==2.2.3" \
         "pyarrow==18.1.0" \
         "jsonschema==4.23.0" \
-        "qfbench2-common @ git+https://github.com/Agenthon-2026/Agenthon2026-public.git@v2.3.1#subdirectory=common"
+        "qfbench2-common @ https://github.com/Agenthon-2026/Agenthon2026-public/archive/refs/tags/v2.3.1.tar.gz#subdirectory=common"
 
 WORKDIR /work
 COPY qfbench2_track_forecasting /opt/qfbench2_track_forecasting

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN pip install --no-cache-dir \
         "numpy==2.1.3" \
         "pandas==2.2.3" \
         "pyarrow==18.1.0" \
-        "jsonschema==4.23.0"
+        "jsonschema==4.23.0" \
+        "qfbench2-common @ git+https://github.com/Agenthon-2026/Agenthon2026-public.git@v2.3.1#subdirectory=common"
 
 WORKDIR /work
 COPY qfbench2_track_forecasting /opt/qfbench2_track_forecasting

--- a/README.md
+++ b/README.md
@@ -238,9 +238,11 @@ every unit before reading any input. The full contract is [`SUBMISSION_CLI.md`](
 >
 > The image installs the shared toolkit itself, so `docker build` followed by
 > `docker run --rm <image> forecast --help` works with no extra steps. If you build your own
-> image from scratch rather than from this `Dockerfile`, carry the `qfbench2-common` line from
-> "Inheriting the shared toolkit" below into it — `qfbench2_track_forecasting.limits` imports
-> the toolkit, so an image without it builds cleanly and then fails at run time.
+> image from scratch rather than from this `Dockerfile`, carry its `qfbench2-common` line across
+> — `qfbench2_track_forecasting.limits` imports the toolkit, so an image without it builds
+> cleanly and then fails at run time. Copy that line from the `Dockerfile` rather than from
+> "Inheriting the shared toolkit" below: slim base images ship no `git`, so the `git+https://`
+> form fails at build time where the tarball form does not.
 > `units/t2-EXAMPLE-ust-curve-1m/run_example.sh` drives the same pipeline through the Python API
 > and also runs offline.
 
@@ -478,6 +480,13 @@ repository that publishes it, `Agenthon-2026/Agenthon2026-public`:
 
 ```bash
 pip install "qfbench2-common @ git+https://github.com/Agenthon-2026/Agenthon2026-public.git@v2.3.1#subdirectory=common"
+```
+
+That form needs a `git` binary. Slim container base images ship none, so inside an image install
+the same tag from its source tarball instead — this is what the repo-root `Dockerfile` does:
+
+```bash
+pip install "qfbench2-common @ https://github.com/Agenthon-2026/Agenthon2026-public/archive/refs/tags/v2.3.1.tar.gz#subdirectory=common"
 ```
 
 **Pin the tag, and pin this one.** `v2.3.1` is the first toolkit release that carries

--- a/README.md
+++ b/README.md
@@ -208,10 +208,10 @@ argument after the image reference. Your image must either expose `forecast` as 
 accept `forecast` as a leading positional argument. An image that ignores the verb exits 2 on
 every unit before reading any input. The full contract is [`SUBMISSION_CLI.md`](SUBMISSION_CLI.md).
 
-> **Status (2026-08-27): the reference implementation ships in this repo — and its image does not
-> run yet.** The paragraph that used to sit here said there was no reference `forecast` CLI, no
-> `argparse` entry point, no `__main__`, no `[project.scripts]` and no `Dockerfile`. All five were
-> true when it was written and none of them is true now, so do not start from scratch:
+> **Status (2026-08-30): the reference implementation and its image both ship in this repo.** The
+> paragraph that used to sit here said there was no reference `forecast` CLI, no `argparse` entry
+> point, no `__main__`, no `[project.scripts]` and no `Dockerfile`. All five were true when it was
+> written and none of them is true now, so do not start from scratch:
 >
 > - `qfbench2_track_forecasting/cli.py` implements the verb above, with a `__main__` guard;
 > - `pyproject.toml` declares `[project.scripts] forecast = "qfbench2_track_forecasting.cli:main"`;

--- a/README.md
+++ b/README.md
@@ -236,12 +236,11 @@ every unit before reading any input. The full contract is [`SUBMISSION_CLI.md`](
 > directory when `--panels` holds no `.parquet`, which is why the command above still runs — but a
 > staged unit really does ship `panels/`, so keep passing `/input/panels/`.
 >
-> **The image is the part that is not finished.** `docker build` succeeds, and then `forecast`
-> inside it dies on `ModuleNotFoundError: No module named 'qfbench2_common'`: the `Dockerfile`
-> installs `numpy`, `pandas`, `pyarrow` and `jsonschema` but not the shared toolkit, which
-> `qfbench2_track_forecasting.limits` imports. Add the `qfbench2-common` line from
-> "Inheriting the shared toolkit" below to your own image, or run the CLI locally against an
-> installed toolkit.
+> The image installs the shared toolkit itself, so `docker build` followed by
+> `docker run --rm <image> forecast --help` works with no extra steps. If you build your own
+> image from scratch rather than from this `Dockerfile`, carry the `qfbench2-common` line from
+> "Inheriting the shared toolkit" below into it — `qfbench2_track_forecasting.limits` imports
+> the toolkit, so an image without it builds cleanly and then fails at run time.
 > `units/t2-EXAMPLE-ust-curve-1m/run_example.sh` drives the same pipeline through the Python API
 > and also runs offline.
 

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -11,15 +11,15 @@ Four legs of the parity matrix need infrastructure that is not present. Each is 
 `skip` with a named reason, because a suite that silently omits a leg reads exactly like a suite
 that passed it:
 
-* **the scoring image** — needs Docker plus a digest-pinned image and registry credentials;
-* **the CodaBench wrapper** — needs a live platform and a bundle upload, which the remediation
-  packet forbids mutating;
+* **the scoring image** — needs Docker plus a published, digest-pinned scoring image;
+* **the submission-platform wrapper** — needs a live platform instance and a bundle upload, which
+  a local run must not perform against a shared instance;
 * **NFC (Unicode) collision** in a staged tree — macOS APFS normalizes filenames, so the two
   colliding names become one file on creation and the case cannot be constructed at all;
 * **case-insensitive collision** — same reason, APFS folds case.
 
-The last two must be exercised in **Linux CI**, and the frozen contract says so normatively:
-"A06 may not be closed on the strength of a local green run."
+The last two must be exercised in **Linux CI**: neither can be constructed on macOS at all, so a
+green local run is not evidence about them and must not be read as any.
 """
 
 from __future__ import annotations
@@ -117,8 +117,8 @@ def test_a_reordered_declaration_is_refused_on_both_paths(tmp_path: pathlib.Path
 
 @pytest.mark.integration
 @pytest.mark.skip(
-    reason="needs Docker, a digest-pinned scoring image and registry credentials; this host has "
-    "Docker but no image and no registry. Run in Linux CI with the image published."
+    reason="needs Docker and a published, digest-pinned scoring image. Run in Linux CI once the "
+    "image is published."
 )
 def test_scoring_image_parity() -> None:  # pragma: no cover - infrastructure
     raise AssertionError("unreachable")
@@ -126,8 +126,8 @@ def test_scoring_image_parity() -> None:  # pragma: no cover - infrastructure
 
 @pytest.mark.integration
 @pytest.mark.skip(
-    reason="needs a live CodaBench instance and a bundle upload; the remediation packet forbids "
-    "mutating live CodaBench state. Run against a staging instance."
+    reason="needs a live submission-platform instance and a bundle upload. Run against a staging "
+    "instance; a local run must not mutate a shared one."
 )
 def test_codabench_wrapper_parity() -> None:  # pragma: no cover - infrastructure
     raise AssertionError("unreachable")
@@ -136,8 +136,8 @@ def test_codabench_wrapper_parity() -> None:  # pragma: no cover - infrastructur
 @pytest.mark.skipif(
     sys.platform == "darwin",
     reason="macOS APFS normalizes filenames to NFC, so the two colliding names become ONE file on "
-    "creation and the collision cannot be constructed. Exercise in Linux CI; the frozen contract "
-    "says A06 may not be closed on a local green run.",
+    "creation and the collision cannot be constructed. Exercise in Linux CI; a green local run is "
+    "not evidence about this case.",
 )
 def test_nfc_collision_in_a_staged_tree_is_refused(tmp_path: pathlib.Path) -> None:
     from qfbench2_common.contracts import digest_tree


### PR DESCRIPTION
## Why

The reference submission image in this repo builds, and then fails on the first
command you give it.

`Dockerfile` installed `numpy`, `pandas`, `pyarrow` and `jsonschema`, but not
`qfbench2-common`. The package the image `COPY`s imports that toolkit in seven
modules — including `limits.py`, which `cli.py` imports at module scope. So the
build goes green and then:

```
$ docker run --rm t2-ref:test forecast --help
ModuleNotFoundError: No module named 'qfbench2_common'
```

A CodaBench submission *is* the Docker image. Anyone who built theirs starting
from this `Dockerfile` got one that cannot run a single unit.

## What changed

**1. The image installs the shared toolkit.** One line added to the existing
`pip install`, pinned to the same `v2.3.1` tag the README and both CI jobs
already use.

It installs from the release **tarball** rather than `git+https://`. pip
implements a VCS URL by shelling out to a `git` binary, and the base image is
`python:3.13-slim-bookworm` — `FROM debian:bookworm-slim`, carrying only
`ca-certificates`, `netbase` and `tzdata`. There is no `git` in it, so the VCS
form does not fail at run time, it fails the build:

```
ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
```

Same repository, same pinned tag, no extra `apt` layer. The two forms were
checked to be equivalent: the installed `qfbench2_common` tree is byte-identical
either way (43 modules, matching sha256) and reports the `CONTRACT_SET` `1.1.0`
that CI asserts.

`scipy` is pinned alongside the rest. Nothing here imports it directly, but
`qfbench2-common` declares `scipy>=1.11` as a hard dependency, so adding the
toolkit also added scipy — and left implicit it would have been the one floating
dependency in an image that pins everything else, which is exactly the failure
mode the comment above that `pip install` warns about.

**2. README.** The section describing the missing toolkit as a known gap is now
wrong, so it is gone. The status banner above it still led with "its image does
not run yet" — also gone. "Inheriting the shared toolkit" keeps the `git+https`
line for local installs, where `git` is normally present, and now also gives the
tarball form for the container case.

**3. CI builds the image.** Nothing in CI ever did. Four jobs covered the Python
package; the image — which is what a submission actually is — was never
constructed, which is why an image that built clean and then died on its first
import looked exactly like a green repository. The new `image` job builds it and
then uses it: the verb starts, the toolkit imports, every dependency is at its
pinned version, it runs under `--network=none` the way the harness runs it, and
it does not run as root. The pin check names `scipy` explicitly, since nothing
here imports it directly and only an assertion keeps it from drifting back to
unpinned. linux/amd64 only — emulating arm64 costs more than it would catch.

**4. `tests/test_parity.py` wording.** The four skipped parity legs described
internal process rather than the technical precondition each one needs. Reworded
to say what is actually required. **No behaviour change** — still the same four
tests, still skipped, for the same reasons.

## Verification

Run against a clean checkout, with an unpatched checkout of the same commit as a
control:

| | base | this branch |
|---|---|---|
| `pytest` | 166 passed, 1 failed, 4 skipped | 166 passed, 1 failed, 4 skipped |
| `ruff check` (CI scope) | clean | clean |
| `ruff format --check` (CI scope) | clean | clean |

The one failure, `test_limits.py::test_uncompressed_budget`, **fails identically
on the unpatched base commit** and is unrelated to this PR. It looks
environment-specific: on arm64 macOS with pyarrow 18.1.0 the parquet footer
reports `total_byte_size` 367 for the 500k-row fixture, under the 1024 threshold
the test asserts on, because the footer records the dictionary/RLE-encoded size
rather than the materialized one. Worth a separate issue; flagging, not fixing here.

**No `docker build` was run to prepare this branch** — the machine it was written
on has no container runtime at all. Everything above was checked without one,
including a rehearsal of the image layout (exact pins, package at `/opt`,
`PYTHONPATH=/opt`), which prints the help text and exits 0. That is a proxy, not
the real thing.

The new `image` job is what settles it, on this PR, on a real Linux runner. Read
it before reading anything else here: if it is red, this branch does not work and
the rest of this description is beside the point.

Wheel availability was checked ahead of it and is not expected to be the problem:
all five pins publish `cp313` `manylinux` wheels for both `x86_64` and `aarch64`,
and `jsonschema` is pure-python. scipy's wheels need glibc >= 2.27/2.28, which
bookworm's 2.36 satisfies. Nothing should need to compile — which matters,
because this base ships no compiler.

## Not fixed here

Two pre-existing problems this PR deliberately leaves alone, both measured
against the base commit and neither caused by these changes:

- **`regression_suite/` is not linted.** CI runs ruff over
  `qfbench2_track_forecasting tests scoring baselines` only, so four errors sit
  there unseen. Track 3 lints its own `regression_suite/`; this repo should too.
- **`max_uncompressed_bytes` cannot bind.** With `max_rows` 5,000,000 and
  `max_columns` 8, the materialized ceiling is ~320 MB, well under the 2 GiB
  budget — so the row and column ceilings always trigger first and the byte
  budget is unreachable. That is why `test_uncompressed_budget` has to drive it
  with an artificial 1024-byte limit to fire at all.
